### PR TITLE
Added year

### DIFF
--- a/app/src/main/java/com/marz/snapprefs/Util/ChatData.java
+++ b/app/src/main/java/com/marz/snapprefs/Util/ChatData.java
@@ -8,7 +8,7 @@ import java.util.Date;
  */
 
 public class ChatData {
-    private final static SimpleDateFormat sdf = new SimpleDateFormat("HH:mm\ndd MMM");
+    private final static SimpleDateFormat sdf = new SimpleDateFormat("HH:mm\ndd MMM\nyyyy");
     private String conversationId;
     private String messageId;
     private String text;


### PR DESCRIPTION
Adds year to Chat Logs, to account for chats more than a year old. They order correctly in the app, but it just looks funny because you might have September above July.